### PR TITLE
Add base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore env files as they are created and removed dynamically
+*.env

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ ./updater/run.sh --update
 ```
 
 This will update each component to the version specified in `targets.env`.
+To generate the `targets.env` file, you must first run the update check command 👆
 It will pull the target version tag from git, and run the migration script for each component version, if it exists in the `migrations` folder.
 
 ## Migrations

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # updater
+
 Update checks and migration scripts for Edgebox
+
+## Usage
+
+### Update check
+
+```bash
+$ ./updater/run.sh --check
+```
+
+This will check the current versions of each component, and fetch the next version of each component via git tags.
+This will create the file `targets.env`, which contains the versions of each component to be updated to.
+
+After running this command, you can then proceed to run the udpate command 👇
+
+### Update
+
+```bash
+$ ./updater/run.sh --update
+```
+
+This will update each component to the version specified in `targets.env`.
+It will pull the target version tag from git, and run the migration script for each component version, if it exists in the `migrations` folder.
+
+## Migrations
+
+Migrations are bash scripts that are run for each component version. They are named after the component-version pair they correspond to, and are placed in the `migrations` folder.
+These scripts are useful to update or install dependencies, or to run any other commands that are required to migrate to the next version of the component.
+For example, the migration script for the `edgeboxctl` component, version `0.0.3` would be named `edgeboxctl-0.0.3.sh`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Update checks and migration scripts for Edgebox
 
+## Installation
+
+This repository should automatically be installed on the Edgebox system setup repository for the target Edgebox platform (`multipass-cofig`, `ua-netinst-config`, `image-builder`)
+In this case, it will be located in `/home/system/components/updater`.
+
+If you have a custom Edgebox setup, or one that does not yet contain this component, you can install this repository manually by running the following commands:
+```bash
+cd /home/system/components
+git clone https://github.com/edgebox-iot/updater.git
+```
+
 ## Usage
 
 ### Update check
@@ -25,7 +36,14 @@ This will update each component to the version specified in `targets.env`.
 To generate the `targets.env` file, you must first run the update check command 👆
 It will pull the target version tag from git, and run the migration script for each component version, if it exists in the `migrations` folder.
 
-## Migrations
+## Development
+
+### Mocking current versions
+
+To test the updated with custom current component versions, you can mock the current versions of each component by creating a file named `versions.env` in the root of this repository.
+This file should contain the current version of each component, in the format `<COMPONENT_NAME>_VERSION=x.x.x`. In case this file does not exist, the updater will attempt to navigate to each target component folder and fetch the current version from the current checked out tag.
+
+### Migration scripts
 
 Migrations are bash scripts that are run for each component version. They are named after the component-version pair they correspond to, and are placed in the `migrations` folder.
 These scripts are useful to update or install dependencies, or to run any other commands that are required to migrate to the next version of the component.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ git clone https://github.com/edgebox-iot/updater.git
 
 ## Usage
 
+Make sure you run the following commands from the root of this repository.
+
 ### Update check
 
 ```bash
-$ ./updater/run.sh --check
+$ ./run.sh --check
 ```
 
 This will check the current versions of each component, and fetch the next version of each component via git tags.
@@ -31,7 +33,7 @@ After running this command, you can then proceed to run the udpate command 👇
 ### Update
 
 ```bash
-$ ./updater/run.sh --update
+$ ./run.sh --update
 ```
 
 This will update each component to the version specified in `targets.env`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+![Edgebox Logo Image](https://adm-listmonk.edgebox.io/uploads/logo_transparent_horizontal_300x100.png)
 # updater
 
-Update checks and migration scripts for Edgebox
+Update checks and migration scripts for the Edgebox system.
+Curious about what the Edgebox is? Check out our [website](https://edgebox.io)!
 
 ## Installation
 

--- a/migrations/edgeboxctl-0.0.3.sh
+++ b/migrations/edgeboxctl-0.0.3.sh
@@ -1,0 +1,5 @@
+# Edgebox updater - 2023-11-25 migration
+# This script is executed during the update process
+
+# Update / install sshx
+curl -sSf https://sshx.io/get | sh

--- a/migrations/edgeboxctl-0.0.3.sh
+++ b/migrations/edgeboxctl-0.0.3.sh
@@ -3,3 +3,13 @@
 
 # Update / install sshx
 curl -sSf https://sshx.io/get | sh
+
+# Go to the edgeboxctl component folder
+cd /home/system/components/edgeboxctl
+
+# Build the edgeboxctl binary and install it
+# TODO: Build for architecture and flavour
+make build-cloud
+
+# Start the edgeboxctl service
+systemctl start edgeboxctl

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,160 @@
+#!/bin/sh
+set -e
+PROGNAME=$(basename $0)
+die() {
+    echo "$PROGNAME: $*" >&2
+    exit 1
+}
+
+usage() {
+    if [ "$*" != "" ] ; then
+        echo "Error: $*"
+    fi
+    cat << EOF
+
+Usage: $PROGNAME [OPTION ...] [foo] [bar]
+
+-----------------------------------------------------------------
+|  CLI tool for building and managing Edgebox updates           |
+-----------------------------------------------------------------
+
+Options:
+-h, --help               display this usage message and exit
+-c, --check              check for updates
+-u, --update             update the system
+
+EOF
+    exit 1
+}
+
+# Update check. This function is called when the --check flag is passed
+# It should check for updates by doing the following:
+# 1. Open the file versions.env and read the current version for each component (ws, api, apps, logger, edgeboxctl)
+# 2. Check in each component folder for the available git tags
+# 3. If there is a newer (semver) tag than the one read from the file, save it to a variable
+# 4. Write the new available next version to the versions.env file
+check() {
+    echo "Checking for updates..."
+
+    # Remove the file targets.env if it exists
+    if [ -f targets.env ]; then
+        rm targets.env
+    fi
+
+    # Check for updates for each component
+    for component in ws api apps logger edgeboxctl; do
+        
+        # Convert to uppercase
+        component_upper=$(echo "$component" | tr '[:lower:]' '[:upper:]')
+
+        # echo "Checking for updates for $component_upper..."
+
+        # TODO: Get the current version from the checked out version, not from the versions.env file
+        # Get the current version from the versions.env file
+        current_version=$(grep -E "^${component_upper}_VERSION=" /home/system/components/updater/versions.env | cut -d '=' -f2)
+
+        # echo "Current version: $current_version"
+        
+        cd /home/system/components/$component
+
+        # echo "Available versions:"
+        # git tag -l | sort -V
+
+        # Get the latest version
+        latest_version=$(git tag -l | sort -V | tail -1)
+        # echo "Latest version: $latest_version"
+
+        # Get the next version
+        next_version=$(git tag -l | sort -V | grep -A1 "$current_version" | tail -1)
+
+        # echo "Next version: $next_version"
+
+        # If there is a next version, save it to the targets.env file
+        if [ "$next_version" != "" ]; then
+            echo "${component_upper}_VERSION=$next_version" >> /home/system/components/updater/targets.env
+        fi
+
+        echo "$component_upper -> Current: $current_version, Next: $next_version, Latest: $latest_version"
+
+        cd /home/system
+    done
+
+    # If there are no updates, exit
+    if [ ! -f targets.env ]; then
+        echo "\nNo updates available"
+        exit 0
+    else
+        echo "\nUpdates available:"
+        cat /home/system/components/updater/targets.env
+    fi
+}
+
+# Update the system. This function is called when the --update flag is passed
+# It should do the following:
+# 1. Open the file targets.env and read the next version for each component (ws, api, apps, logger, edgeboxctl)
+# 2. Go to each component folder and checkout the next version
+# 3. Run the update script for each component
+# 4. Update the versions.env file with the new versions
+update() {
+    echo "Updating the system..."
+
+    # Check if the targets.env file exists
+    if [ ! -f targets.env ]; then
+        echo "No updates available. Run ./run.sh --check to check for updates"
+        exit 0
+    fi
+
+    # Update each component
+    for component in ws api apps logger edgeboxctl; do
+        # Get the next version from the targets.env file
+        next_version=$(grep -E "^${component_upper}_VERSION=" /home/system/components/updater/targets.env | cut -d '=' -f2)
+
+        # Go to the component folder
+        cd /home/system/components/$component
+
+        # Checkout the next version
+        git checkout $next_version
+
+        # Run the update migration for this component, if it exists
+        if [ -f /home/system/components/$component/updater/migrations/$component-$next_version.sh ]; then
+            echo "Running migration for $component $next_version"
+            /home/system/components/$component/updater/migrations/$component-$next_version.sh
+        fi
+
+        cd /home/system
+    done
+
+    # Remove the targets.env file
+    rm targets.env
+
+    echo "Update complete"
+}
+
+while [ $# -gt 0 ] ; do
+    case "$1" in
+    -h|--help)
+        usage
+        ;;
+    -c|--check)
+        check
+        ;;
+    -u|--update)
+        update
+        ;;
+    -*)
+        usage "Unknown option '$1'"
+        ;;
+    *)
+        break
+        ;;
+    esac
+    shift
+done
+
+cat <<EOF
+
+-----------------------
+| Operation Completed. | 
+-----------------------
+
+EOF


### PR DESCRIPTION
This is a concept for a script that checks and updates versions of Edgebox components based on the available git repository tags.

## Usage

Clone this repo in the /home/system/components/ folder of a fully working edgebox system.
Create a dummy `versions.sh` file in this repo folder (right now to mock the behaviour as we don't yet have a check_versions function, see the TODO line in the code. THis env file will be .gitignored).
Type `./run.sh --check` to run the update checker.

```bash
/home/system/components/updater# ./run.sh -c
Checking for updates...
WS -> Current: 0.0.1, Next: 0.0.1, Latest: 0.0.1
API -> Current: 0.0.1, Next: 0.1.0, Latest: 0.2.1
APPS -> Current: 0.0.1, Next: 0.0.1, Latest: 0.0.1
LOGGER -> Current: , Next: , Latest: 
EDGEBOXCTL -> Current: 0.0.1, Next: 0.0.2, Latest: 0.0.2

Updates available:
WS_VERSION=0.0.1
API_VERSION=0.1.0
APPS_VERSION=0.0.1
EDGEBOXCTL_VERSION=0.0.2

-----------------------
| Operation Completed. | 
-----------------------

```

(A working edgebox system needs to have the `api`, `apps`, `edgeboxctl`, `ws` and `logger` repos cloned to the components folder, with a functioning edgeboxctl system service running).

### The check command
It _checks the current version of each component*_, check for the next available version based on the current one, and writes the information to the `targets.sh` file.

### The update command

This will update each component to the version specified in `targets.env`.
It will pull the target version tag from git, and run the migration script for each component version, if it exists in the `migrations` folder.

### Migrations

Migrations are scripts that run for a specific component+version_tag. For example `edgeboxctl-0.0.3.sh`, pertaining a future release of this component.
Once the new tag is released on the specific component repository, and if `targets.env` value for this component is set to the new tag, once the `./run.sh --update` command is ran, it will check out the target version and run the migration script afterwards.